### PR TITLE
Make Entry Link More Visible

### DIFF
--- a/akalisten/templates/lotsude/index.j2
+++ b/akalisten/templates/lotsude/index.j2
@@ -26,30 +26,32 @@
                 <span class="accordion-icon">⬇️</span>
             </button>
             <div class="accordion-content mucke" id="mucke-{{ poll.id }}" hidden>
-                {% if poll.url %}
-                    <div class="entry-link">
-                        🔗 <a href="{{ poll.url }}" target="_blank" rel="noopener noreferrer">Hier zur Mucke eintragen</a>
-                    </div>
-                {%  endif %}
-                {% if poll.mucken_info.has_any_info or poll.mucken_info.additional %}
-                    <div class="accordion" data-state="closed">
-                        <button class="accordion-header" aria-expanded="false" aria-controls="mucke-{{ poll.id }}-infos">
-                            Mucken-Infos
-                            <span class="accordion-icon">⬇️</span>
-                        </button>
-                        <div class="accordion-content mucken-infos" id="mucke-{{ poll.id }}-infos" hidden>
-                            {% if poll.mucken_info.has_any_info %}
-                                {{ poll.mucken_info.html_info }}
-                            {% endif %}
-                            {% if poll.mucken_info.additional %}
-                                <p>
-                                    <b>📝 Zusätzliche Informationen:</b>
-                                    {{ poll.mucken_info.html_additional }}
-                                </p>
-                            {% endif %}
+                <div class="mucken-header" id="mucke-{{ poll.id }}-header">
+                    {% if poll.mucken_info.has_any_info or poll.mucken_info.additional %}
+                        <div class="accordion" data-state="closed">
+                            <button class="accordion-header" aria-expanded="false" aria-controls="mucke-{{ poll.id }}-infos">
+                                Mucken-Infos
+                                <span class="accordion-icon">⬇️</span>
+                            </button>
+                            <div class="accordion-content mucken-infos" id="mucke-{{ poll.id }}-infos" hidden>
+                                {% if poll.mucken_info.has_any_info %}
+                                    {{ poll.mucken_info.html_info }}
+                                {% endif %}
+                                {% if poll.mucken_info.additional %}
+                                    <p>
+                                        <b>📝 Zusätzliche Informationen:</b>
+                                        {{ poll.mucken_info.html_additional }}
+                                    </p>
+                                {% endif %}
+                            </div>
                         </div>
-                    </div>
-                {% endif %}
+                    {% endif %}
+                    {% if poll.url %}
+                        <button class="entry-btn">
+                            🔗 <a href="{{ poll.url }}" target="_blank" rel="noopener noreferrer">Hier zur Mucke eintragen</a>
+                        </button>
+                    {%  endif %}
+                </div>
 
                 <div class="filters">
                     <div class="participant-filter">

--- a/akalisten/templates/lotsude/style.css
+++ b/akalisten/templates/lotsude/style.css
@@ -159,7 +159,7 @@ footer {
     margin: 10px 0;
     border-radius: 5px;
     overflow: hidden;
-    flex: 1 1 100%;
+    flex: 2 2 70%;
     min-width: 250px;
 }
 .accordion-header {
@@ -216,7 +216,7 @@ footer {
     gap: 10px 25px;
 }
 .entry-btn {
-    flex: 0 1 100%;
+    flex: 1;
     margin: 10px 0;
     border: none;
     font-weight: bold;

--- a/akalisten/templates/lotsude/style.css
+++ b/akalisten/templates/lotsude/style.css
@@ -91,6 +91,13 @@ footer {
     justify-content: space-between;
 }
 
+.mucken-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 10px;
+}
+
 .filters {
     display: flex;
     justify-content: center;
@@ -152,6 +159,8 @@ footer {
     margin: 10px 0;
     border-radius: 5px;
     overflow: hidden;
+    flex: 1 1 100%;
+    min-width: 250px;
 }
 .accordion-header {
     border: 1px solid var(--border);
@@ -206,8 +215,20 @@ footer {
 .mucke {
     gap: 10px 25px;
 }
-.entry-link {
+.entry-btn {
+    flex: 0 1 100%;
+    margin: 10px 0;
+    border: none;
     font-weight: bold;
+    background-color: var(--link);
+    color: var(--button-text);
+    white-space: nowrap;
+    height: max-content;
+    padding: 15px;
+}
+.entry-btn a {
+    color: var(--button-text);
+    text-decoration: none;
 }
 .mucken-infos {
     background-color: var(--accent-background);
@@ -226,6 +247,9 @@ footer {
     }
     .column {
         min-width: auto;
+    }
+    .mucken-header {
+        flex-direction: column;
     }
     .accordion-content {
         padding: 15px 10px;


### PR DESCRIPTION
Closes #2

CSS things can probably be improved (in terms of clean code), but so far it looks like it does the trick:

* muckeninfo and entry link are displayed on the same row on wide screens
* on narrow screens, entry link breaks to next line and fills the whole width