### PR TITLE
Revert to Using Category Name

### DIFF
--- a/akalisten/templates/lotsude/index.j2
+++ b/akalisten/templates/lotsude/index.j2
@@ -64,7 +64,7 @@
                         <select class="category-select" id="category-select-{{ poll.id }}">
                             <option value="all">Alle</option>
                             {% for option_id, votes in poll_votes[poll.id].options.items() %}
-                                <option value="{{ option_id }}">{{ votes.text }}</option>
+                                <option value="{{ votes.text }}">{{ votes.text }}</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/akalisten/templates/lotsude/index.j2
+++ b/akalisten/templates/lotsude/index.j2
@@ -66,6 +66,7 @@
                             {% for option_id, votes in poll_votes[poll.id].options.items() %}
                                 <option value="{{ votes.text }}">{{ votes.text }}</option>
                             {% endfor %}
+                                <option hidden value="unknown" class="strikethrough">Unbekannt</option>
                         </select>
                     </div>
                 </div>

--- a/akalisten/templates/lotsude/option_block.j2
+++ b/akalisten/templates/lotsude/option_block.j2
@@ -1,6 +1,6 @@
 {% macro render_category(votes, vote_type) %}
     {% set users = votes[vote_type]() %}
-    <div class="category{% if not users %} placeholder{% endif %}" data-category-id="{{ votes.id }}">
+    <div class="category{% if not users %} placeholder{% endif %}" data-category-name="{{ votes.text }}">
         <div class="category-name">{{ votes.text }}</div>
         <ul>
             {% for user in users %}

--- a/akalisten/templates/lotsude/script.j2
+++ b/akalisten/templates/lotsude/script.j2
@@ -2,10 +2,22 @@
 document.addEventListener('DOMContentLoaded', function() {
     const tabContent = document.querySelector('.mucken');
     if (tabContent) {
+        function getSelectedCategory() {
+            // Simply selecting the first element doesn't suffice b/c the selected category might
+            // not be known for that selection. We need to find the first non-unknown category.
+            let selectedCategory = Array.from(document.querySelectorAll('.category-select'))
+              .map(select => select.value)
+              .find(value => value && value !== "unknown") || "all";
+            if (document.querySelectorAll('.category-select').length === 0) {
+              return "all";
+            }
+            return selectedCategory;
+        }
+
         function updateVisibility() {
             const activeFilterButton = tabContent.querySelector('.filter-btn.active');
             const selectedStatus = activeFilterButton ? activeFilterButton.getAttribute('data-filter') : 'all';
-            let selectedCategory = document.querySelector('.category-select') ? document.querySelector('.category-select').value : 'all';
+            const selectedCategory = getSelectedCategory();
 
             tabContent.querySelectorAll('.column').forEach(column => {
                 const shouldHideColumn = !(selectedStatus === 'all' || column.classList.contains(selectedStatus));
@@ -13,8 +25,15 @@ document.addEventListener('DOMContentLoaded', function() {
             });
 
             tabContent.querySelectorAll('.category').forEach(category => {
-                const shouldHideCategory = !((selectedCategory === 'all' || category.getAttribute('data-category-name') === selectedCategory) &&
-                    (selectedStatus === 'all' || category.closest('.column').classList.contains(selectedStatus)));
+                const shouldHideCategory = !(
+                    (
+                        selectedCategory === 'all'
+                        || category.getAttribute('data-category-name') === selectedCategory
+                    ) && (
+                        selectedStatus === 'all'
+                        || category.closest('.column').classList.contains(selectedStatus)
+                    )
+                );
                 category.classList.toggle('hidden', shouldHideCategory);
             });
         }
@@ -36,28 +55,18 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
 
+        function handleUnknownOption(select, selectedText) {
+            if (select.options[select.selectedIndex] === undefined) {
+                select.value = "unknown";
+                select.options[select.selectedIndex].text = selectedText;
+                select.classList.add('strikethrough');
+            } else {
+                select.classList.remove('strikethrough');
+            }
+        }
+
         function setupCategorySelects() {
             const categorySelects = document.querySelectorAll('.category-select');
-            categorySelects.forEach(select => {
-                select.addEventListener('change', function() {
-                    const selectedValue = this.value;
-                    const selectedText = this.options[this.selectedIndex].text;
-
-                    categorySelects.forEach(otherSelect => {
-                        otherSelect.value = selectedValue;
-                        if (otherSelect.options[otherSelect.selectedIndex] === undefined) {
-                            otherSelect.value = "unknown";
-                            otherSelect.options[otherSelect.selectedIndex].text = selectedText;
-                            otherSelect.classList.add('strikethrough');
-                        } else {
-                            otherSelect.classList.remove('strikethrough');
-                        }
-                    });
-                    localStorage.setItem('selectedCategory', selectedValue);
-                    updateVisibility();
-                });
-            });
-
             // Restore selected category from localStorage
             const savedCategory = localStorage.getItem('selectedCategory');
             if (savedCategory) {
@@ -65,6 +74,21 @@ document.addEventListener('DOMContentLoaded', function() {
                     select.value = savedCategory;
                 });
             }
+
+            const selectedCategory = getSelectedCategory();
+            categorySelects.forEach(select => {
+                handleUnknownOption(select, selectedCategory);
+
+                select.addEventListener('change', function() {
+                    const selectedValue = this.value;
+                    categorySelects.forEach(otherSelect => {
+                        otherSelect.value = selectedValue;
+                        handleUnknownOption(otherSelect, this.options[this.selectedIndex].text);
+                    });
+                    localStorage.setItem('selectedCategory', selectedValue);
+                    updateVisibility();
+                });
+            });
         }
 
         function setupAccordion() {

--- a/akalisten/templates/lotsude/script.j2
+++ b/akalisten/templates/lotsude/script.j2
@@ -41,8 +41,17 @@ document.addEventListener('DOMContentLoaded', function() {
             categorySelects.forEach(select => {
                 select.addEventListener('change', function() {
                     const selectedValue = this.value;
+                    const selectedText = this.options[this.selectedIndex].text;
+
                     categorySelects.forEach(otherSelect => {
                         otherSelect.value = selectedValue;
+                        if (otherSelect.options[otherSelect.selectedIndex] === undefined) {
+                            otherSelect.value = "unknown";
+                            otherSelect.options[otherSelect.selectedIndex].text = selectedText;
+                            otherSelect.classList.add('strikethrough');
+                        } else {
+                            otherSelect.classList.remove('strikethrough');
+                        }
                     });
                     localStorage.setItem('selectedCategory', selectedValue);
                     updateVisibility();

--- a/akalisten/templates/lotsude/script.j2
+++ b/akalisten/templates/lotsude/script.j2
@@ -13,7 +13,7 @@ document.addEventListener('DOMContentLoaded', function() {
             });
 
             tabContent.querySelectorAll('.category').forEach(category => {
-                const shouldHideCategory = !((selectedCategory === 'all' || category.getAttribute('data-category-id') === selectedCategory) &&
+                const shouldHideCategory = !((selectedCategory === 'all' || category.getAttribute('data-category-name') === selectedCategory) &&
                     (selectedStatus === 'all' || category.closest('.column').classList.contains(selectedStatus)));
                 category.classList.toggle('hidden', shouldHideCategory);
             });

--- a/akalisten/templates/lotsude/style.css
+++ b/akalisten/templates/lotsude/style.css
@@ -227,6 +227,10 @@ li.placeholder {
     opacity: 0.5;
 }
 
+.strikethrough {
+    text-decoration: line-through;
+}
+
 @media only screen and (max-width: 420px) {
     body {
         padding: 20px 10px;


### PR DESCRIPTION
closes #22

Note that if the category is available in only one of the mucken, there is still some undefined behavior:

![image](https://github.com/user-attachments/assets/dbf158eb-4922-4a6f-9c35-fce95c337964)

I don't yet have an idea if this can be handled better, but wanted to point this out before merging